### PR TITLE
Fix bin script execution on Linux

### DIFF
--- a/.changeset/dry-planes-rush.md
+++ b/.changeset/dry-planes-rush.md
@@ -1,0 +1,5 @@
+---
+'@wkovacs64/add-icon': patch
+---
+
+Fix bin script execution on Linux by simplifying the entry point file

--- a/bin/add-icon.js
+++ b/bin/add-icon.js
@@ -1,19 +1,5 @@
 #!/usr/bin/env node
 
-import url from 'node:url';
-import path from 'node:path';
-import os from 'node:os';
 import { runCli } from '../dist/index.js';
 
-const __filename = url.fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-// This logic ensures we only run the CLI when this file is called directly
-// and not when it's imported as a module
-if (
-  os.platform() === 'win32'
-    ? process.argv[1] === __filename
-    : process.argv[1] === __filename || process.argv[1] === __dirname
-) {
-  runCli();
-}
+runCli();


### PR DESCRIPTION
Simplified the bin script by removing unnecessary OS checks and complex path logic.

🤖 Generated with [Claude Code](https://claude.ai/code)